### PR TITLE
Added support for dumping the CA certificate that's sent with the device auth response

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Failing to do so will lead to connection termination. The default interval seems
 
 Device authentication enables a sender to authenticate a Chromecast device. Authenticating the device is purely optional from a sender's perspective, though the official SDK libraries do it to prevent rogue Chromecast devices to communicate with the official sender platforms. Device authentication is taken care of by the `urn:x-cast:com.google.cast.tp.deviceauth` namespace / protocol.
 
-First the sender sends a *challenge* message to the platform receiver `receiver-0` which responds by either a *response* message containing a signature and a certificate or an *error* message. These 3 payloads are protocol buffers encoded and described in `cast_channel.proto` as follows :
+First the sender sends a *challenge* message to the platform receiver `receiver-0` which responds by either a *response* message containing a signature, certificate and a variable number of certificate authority certificates that the sent certificate is verified against or an *error* message. These 3 payloads are protocol buffers encoded and described in `cast_channel.proto` as follows :
 
 ```protobuf
 message AuthChallenge {
@@ -171,6 +171,7 @@ message AuthChallenge {
 message AuthResponse {
   required bytes signature = 1;
   required bytes client_auth_certificate = 2;
+  repeated bytes client_ca = 3;
 }
 
 message AuthError {

--- a/bin/dump-auth-response
+++ b/bin/dump-auth-response
@@ -22,24 +22,33 @@ var opts = {
 };
 
 client.connect(opts, function() {
-  var deviceauth = client.createChannel('urn:x-cast:com.google.cast.tp.deviceauth');
+  var deviceauth = client.createChannel('sender-0', 'receiver-0', 'urn:x-cast:com.google.cast.tp.deviceauth');
 
-  deviceauth.send('sender-0', 'receiver-0', DeviceAuthMessage.serialize({ challenge: {} }));
-  deviceauth.on('message', function(sourceId, destinationId, data) {
+  deviceauth.send(DeviceAuthMessage.serialize({ challenge: {} }));
+  deviceauth.on('message', function(data, broadcast) {
     var response = DeviceAuthMessage.parse(data).response;
     client.close();
 
     var sigFilename = 'auth-signature.sig';
     var certFilenameDer = 'auth-certificate.der';
 
-    fs.writeFileSync(sigFilename, response.signature);
-    fs.writeFileSync(certFilenameDer, response.clientAuthCertificate);
+    fs.writeFileSync(sigFilename, response.signature.toString("binary"), "binary");
+    fs.writeFileSync(certFilenameDer, response.client_auth_certificate.toString("binary"), "binary");
 
     var certFilenamePem = 'auth-certificate.pem';
 
     exec('openssl x509 -in ' + certFilenameDer + ' -inform DER -out ' + certFilenamePem + ' -outform PEM; rm ' + certFilenameDer);
 
     console.log('output written to %s and %s', sigFilename, certFilenamePem);
+
+    for(var i = 0; i < response.client_ca.length; i++) {
+      var ca = response.client_ca[i];
+      var ca_name = 'auth-ca' + (i + 1) + '.crt';
+
+      fs.writeFileSync(ca_name, ca.toString("binary"), "binary");
+
+      console.log('CA written to %s', ca_name);
+    }
   });
 
 });

--- a/lib/cast_channel.proto
+++ b/lib/cast_channel.proto
@@ -60,6 +60,7 @@ message AuthChallenge {
 message AuthResponse {
   required bytes signature = 1;
   required bytes client_auth_certificate = 2;
+  repeated bytes client_ca = 3;
 }
 
 message AuthError {


### PR DESCRIPTION
The code also wouldn't run in its current form for me, so I had to rewrite it slighty, I hope that didn't break anything (it runs just fine for me however).