### PR TITLE
stop null referencing error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -50,10 +50,14 @@ Client.prototype.connect = function(options, callback) {
 
   function onclose() {
     debug('connection closed');
-    self.ps.removeListener('packet', onpacket);
-    self.socket.removeListener('error', onerror);
-    self.socket = null;
-    self.ps = null;
+    if (self.ps) {
+        self.ps.removeListener('packet', onpacket);
+        self.ps = null;
+    }
+    if (self.socket) {
+        self.socket.removeListener('error', onerror);
+        self.socket = null;
+    }
     self.emit('close');
   }
 


### PR DESCRIPTION
I'm constantly getting the following crash

    …node_modules/castv2-client/node_modules/castv2/lib/client.js:53
    self.ps.removeListener('packet', onpacket);
           ^
    TypeError: Cannot read property 'removeListener' of null
    at TLSSocket.onclose (/Users/davidjanes/iotdb/iot/homestar-chromecast/node_modules/chromecast-js/node_modules/castv2-client/node_modules/castv2/lib/client.js:53:12)
    at TLSSocket.g (events.js:199:16)
    at TLSSocket.emit (events.js:107:17)
    at TCP.close (net.js:485:12)

I'm not sure of the exact triggering mechanism - perhaps onclose is being called twice. It happens after several hours of operation.

The code change checks to see if values are null