### PR TITLE
bump debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "index.js",
   "dependencies": {
-    "debug": "~0.8.1",
+    "debug": "~1.0.1",
     "protobufjs": "^3.2.2"
   },
   "scripts": {


### PR DESCRIPTION
Fixes an issue with Electron when where we run in debug=castv2 mode, we get "Illegal invocation" on console.log.

I'm not sure whether this will exist in pure node.js, but it does in Electron.