### PR TITLE
When socket cannot connect, the close tried to use self.ps which was not

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -50,11 +50,12 @@ Client.prototype.connect = function(options, callback) {
 
   function onclose() {
     debug('connection closed');
-    if (self.ps)
-        self.ps.removeListener('packet', onpacket);
     self.socket.removeListener('error', onerror);
     self.socket = null;
-    self.ps = null;
+    if (self.ps) {
+        self.ps.removeListener('packet', onpacket);
+        self.ps = null;
+    }
     self.emit('close');
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -50,7 +50,8 @@ Client.prototype.connect = function(options, callback) {
 
   function onclose() {
     debug('connection closed');
-    self.ps.removeListener('packet', onpacket);
+    if (self.ps)
+        self.ps.removeListener('packet', onpacket);
     self.socket.removeListener('error', onerror);
     self.socket = null;
     self.ps = null;


### PR DESCRIPTION
Fix uncaught exception on client.close() when socket did not connect

Client error: {"code":"ECONNREFUSED","errno":"ECONNREFUSED","syscall":"connect","address":"192.168.2.106","port":33009}

```
2015-12-31 10:55:49.687  - error: uncaught exception: Cannot read property 'removeListener' of null
2015-12-31 10:55:49.708  - error: TypeError: Cannot read property 'removeListener' of null
    at TLSSocket.onclose (/opt/iobroker/node_modules/iobroker.chromecast/node_modules/castv2-client/node_modules/castv2/lib/client.js:53:12)
    at emitOne (events.js:82:20)
    at TLSSocket.emit (events.js:169:7)
    at TCP._onclose (net.js:469:12)
---------------------------------------------
    at Client.connect (/opt/iobroker/node_modules/iobroker.chromecast/node_modules/castv2-client/node_modules/castv2/lib/client.js:44:15)
    at PlatformSender.connect (/opt/iobroker/node_modules/iobroker.chromecast/node_modules/castv2-client/lib/senders/platform.js:27:15)
```