### PR TITLE
Fix Buffer.concat bug

### DIFF
--- a/lib/packet-stream-wrapper.js
+++ b/lib/packet-stream-wrapper.js
@@ -38,7 +38,7 @@ inherits(PacketStreamWrapper, EventEmitter);
 PacketStreamWrapper.prototype.send = function(buf) {
   var header = new Buffer(4);
   header.writeUInt32BE(buf.length, 0);
-  this.stream.write(Buffer.concat([header, buf]));
+  this.stream.write(Buffer.concat([header, Buffer.from(buf)]));
 };
 
 module.exports = PacketStreamWrapper;


### PR DESCRIPTION
In alternate javascript environments (like QuickJS), protobufjs will return ES6 ArrayBuffers and not Node Buffers. This causes the Buffer.concat to fail. Ensure that a Buffer is passed to concat.